### PR TITLE
Add package dependencies to sidebar of package page

### DIFF
--- a/src/backend/Routes.hs
+++ b/src/backend/Routes.hs
@@ -20,6 +20,7 @@ import System.FilePath
 import qualified Elm.Compiler.Module as Module
 import qualified Elm.Docs as Docs
 import qualified Elm.Package as Pkg
+import qualified Elm.Package.Constraint as Constraint
 import qualified Elm.Package.Description as Desc
 import qualified Elm.Package.Paths as Path
 import qualified GitHub
@@ -47,6 +48,7 @@ package =
         <|>
         route
           [ ("latest", redirectToLatest pkg)
+          , ("constraint/:constraint", redirectToConstraint pkg)
           , (":version", servePackageInfo pkg)
           ]
 
@@ -86,15 +88,34 @@ redirectToLatest name =
       case maybeVersions of
         Just versions@(_:_) ->
           do  let latestVersion = last (List.sort versions)
-              let url = "/packages/" ++ Pkg.toUrl name ++ "/" ++ Pkg.versionToString latestVersion ++ "/"
-              request <- getRequest
-              redirect (BS.append (BS.pack url) (rqPathInfo request))
+              redirectToPkgPage name latestVersion
 
         _ ->
-          httpStringError 404 $
-            "Could not find any versions of package " ++ Pkg.toString name
+          noPkgError name
 
 
+redirectToConstraint :: Pkg.Name -> Snap ()
+redirectToConstraint name =
+  do  maybeVersions <- liftIO $ PkgSummary.readVersionsOf name
+      rawConstraint <- getParameter "constraint" Right
+      case maybeVersions of
+        Just versions@(_:_) ->
+          case Constraint.fromString(rawConstraint) of
+            Just constraint ->
+              do  let validVersions =  List.sort (filter (Constraint.isSatisfied constraint) versions)
+                  if length validVersions > 0
+                    then do
+                      redirectToPkgPage name (last validVersions)
+                    else
+                      httpStringError 404 $
+                        "No packages satisfy the given constraint " ++ Pkg.toString name ++ " " ++ rawConstraint
+
+            Nothing ->
+              httpStringError 404 $
+                "Invalid constraint " ++ rawConstraint
+
+        _ ->
+          noPkgError name
 
 
 -- DIRECTORIES
@@ -387,6 +408,19 @@ fetch filePath =
 
 
 -- HELPERS
+
+
+noPkgError :: Pkg.Name -> Snap a
+noPkgError name =
+  httpStringError 404 $
+    "Could not find any versions of package " ++ Pkg.toString name
+
+
+redirectToPkgPage :: Pkg.Name -> Pkg.Version -> Snap a
+redirectToPkgPage name version =
+  do  let url = "/packages/" ++ Pkg.toUrl name ++ "/" ++ Pkg.versionToString version ++ "/"
+      request <- getRequest
+      redirect (BS.append (BS.pack url) (rqPathInfo request))
 
 
 getParameter :: BS.ByteString -> (String -> Either String a) -> Snap a

--- a/src/frontend/Component/Description.elm
+++ b/src/frontend/Component/Description.elm
@@ -1,0 +1,109 @@
+module Component.Description exposing (Model, Msg, init, update, view)
+
+import Html exposing (..)
+import Html.Attributes exposing (..)
+import Http
+import Task
+
+import Docs.Description as Desc
+import Page.Context as Ctx
+import Utils.Path as Path exposing ((</>))
+
+
+type Model
+    = Loading
+    | Failed Http.Error
+    | Success
+        { context : Ctx.VersionContext
+        , description : Desc.Description
+        }
+
+
+init : Ctx.VersionContext -> (Model, Cmd Msg)
+init context =
+  ( Loading
+  , loadDescription context
+  )
+
+
+-- UPDATE
+
+
+type Msg
+    = Fail Http.Error
+    | Load Ctx.VersionContext Desc.Description
+
+
+update : Msg -> Model -> (Model, Cmd Msg)
+update msg model =
+  case msg of
+    Fail httpError ->
+        ( Failed httpError
+        , Cmd.none
+        )
+
+    Load context description ->
+        ( Success
+            { context = context
+            , description = description
+            }
+        , Cmd.none
+        )
+
+
+-- EFFECTS
+
+
+loadDescription : Ctx.VersionContext -> Cmd Msg
+loadDescription context =
+  Task.perform Fail (Load context) (Ctx.getDescription context)
+
+
+-- VIEW
+
+
+view : Model -> Html Msg
+view model =
+  div [] <|
+    case model of
+      Loading ->
+          [ p [] [text "Loading..."]
+          ]
+
+      Failed httpError ->
+          [ p [] [text "Problem loading!"]
+          , p [] [text (toString httpError)]
+          ]
+
+      Success {description} ->
+          [ dependencyHeader description.dependencies
+          , dependencyLinks description.dependencies
+          ]
+
+dependencyHeader : List Desc.Dependency -> Html Msg
+dependencyHeader dependencies =
+  h2
+    []
+    [ text <| "Dependencies (" ++ toString (List.length dependencies) ++ ")" ]
+
+
+dependencyLinks : List Desc.Dependency -> Html Msg
+dependencyLinks dependencies =
+  ul
+    []
+    <| List.map dependencyLink (List.sortBy fst dependencies)
+
+
+dependencyLink : Desc.Dependency -> Html Msg
+dependencyLink (name, constraint) =
+  li
+    [ class "pkg-nav-value" ]
+    [ a
+      [ href (constraintUrl name constraint) ]
+      [ text name ]
+    ]
+
+
+constraintUrl : String -> String -> String
+constraintUrl name constraint =
+  "/packages" </> name </> "constraint" </> constraint

--- a/src/frontend/Component/PackageSidebar.elm
+++ b/src/frontend/Component/PackageSidebar.elm
@@ -145,7 +145,7 @@ gatherTagInfo topLevelNames entry =
 
 view : Model -> Html Msg
 view model =
-  div [class "pkg-nav"] <|
+  div [] <|
     case model of
       Loading ->
           [ p [] [text "Loading..."]

--- a/src/frontend/Docs/Description.elm
+++ b/src/frontend/Docs/Description.elm
@@ -1,0 +1,32 @@
+module Docs.Description exposing (Description, Dependency, decoder)
+
+import Json.Decode exposing (..)
+
+
+type alias Dependency = (String, String)
+
+
+type alias Description =
+    { version : String
+    , summary : String
+    , repository : String
+    , license : String
+    , soruceDirectories : List String
+    , exposedModules : List String
+    , dependencies : List Dependency
+    , elmVersion : String
+    }
+
+
+decoder : Decoder Description
+decoder =
+  object8
+    Description
+    ("version" := string)
+    ("summary" := string)
+    ("repository" := string)
+    ("license" := string)
+    ("source-directories" := list string)
+    ("exposed-modules" := list string)
+    ("dependencies" := keyValuePairs string)
+    ("elm-version" := string)

--- a/src/frontend/Page/Context.elm
+++ b/src/frontend/Page/Context.elm
@@ -2,7 +2,8 @@ module Page.Context exposing (..)
 
 import Http
 import Task
-import Docs.Package as Docs
+import Docs.Package as Package
+import Docs.Description as Description
 import Utils.Path exposing ((</>))
 
 
@@ -27,9 +28,17 @@ getReadme context =
   Http.getString (pathTo context "README.md")
 
 
-getDocs : VersionContext -> Task.Task Http.Error Docs.Package
+getDocs : VersionContext -> Task.Task Http.Error Package.Package
 getDocs context =
-  Http.get Docs.decodePackage (pathTo context "documentation.json")
+  Http.get Package.decodePackage (pathTo context "documentation.json")
+
+
+getDescription : VersionContext -> Task.Task Http.Error Description.Description
+getDescription {user,project,version} =
+  let
+    path = "/description?name=" ++ user </> project ++ "&version=" ++ version
+  in
+    Http.get Description.decoder path
 
 
 pathTo : VersionContext -> String -> String

--- a/src/frontend/Page/Package.elm
+++ b/src/frontend/Page/Package.elm
@@ -3,11 +3,11 @@ module Page.Package exposing (..)
 import Html exposing (..)
 import Html.App as Html
 import Html.Attributes exposing (..)
-import Task
 
 import Component.Header as Header
 import Component.PackageDocs as PDocs
 import Component.PackageSidebar as PkgNav
+import Component.Description as Desc
 import Page.Context as Ctx
 import Route
 
@@ -15,7 +15,7 @@ import Route
 
 -- WIRES
 
-
+main : Program Ctx.VersionContext
 main =
   Html.programWithFlags
     { init = init
@@ -33,6 +33,7 @@ type alias Model =
     { header : Header.Model
     , moduleDocs : PDocs.Model
     , pkgNav : PkgNav.Model
+    , desc : Desc.Model
     }
 
 
@@ -51,12 +52,16 @@ init context =
 
     (pkgNav, navCmd) =
       PkgNav.init context
+
+    (desc, descCmd) =
+      Desc.init context
   in
-    ( Model header moduleDocs pkgNav
+    ( Model header moduleDocs pkgNav desc
     , Cmd.batch
         [ headerCmd
         , Cmd.map UpdateDocs moduleCmd
         , Cmd.map UpdateNav navCmd
+        , Cmd.map UpdateDesc descCmd
         ]
     )
 
@@ -68,6 +73,7 @@ init context =
 type Msg
     = UpdateDocs PDocs.Msg
     | UpdateNav PkgNav.Msg
+    | UpdateDesc Desc.Msg
 
 
 update : Msg -> Model -> (Model, Cmd Msg)
@@ -91,6 +97,15 @@ update msg model =
           , Cmd.map UpdateNav fx
           )
 
+    UpdateDesc descMsg ->
+        let
+          (newDesc, fx) =
+            Desc.update descMsg model.desc
+        in
+          ( { model | desc = newDesc }
+          , Cmd.map UpdateDesc fx
+          )
+
 
 
 -- VIEW
@@ -100,7 +115,11 @@ view : Model -> Html Msg
 view model =
   Header.view model.header
     [ Html.map UpdateDocs (PDocs.view model.moduleDocs)
-    , Html.map UpdateNav (PkgNav.view model.pkgNav)
+    , div
+        [ class "pkg-nav" ]
+        [ Html.map UpdateNav (PkgNav.view model.pkgNav)
+        , Html.map UpdateDesc (Desc.view model.desc)
+        ]
     ]
 
 


### PR DESCRIPTION
This addresses #147 by adding dependency information to the sidebar of each package page. 
## Frontend

Dependency information was added below the module docs. It includes a header that shows the number of dependencies followed by a link for each. The link for each dependency redirects to the package page for the highest version that fits the constraint. For example, if `elm-module` has versions 1.0.0, 1.1.0, and 2.0.0; and its dependency constraint is `1.0.0 <= v < 2.0.0`, then the link would redirect to version 1.1.0. 

The dependency information comes from package description route `/description?name=user/project&version=1.0.0`. A model, task, and decoder was added to fetch this information. 

![with-dependencies](https://cloud.githubusercontent.com/assets/2292766/15693905/46d6a81e-2767-11e6-9287-44469d4c354c.png)

![no-dependencies](https://cloud.githubusercontent.com/assets/2292766/15693887/2eb79504-2767-11e6-9f64-f513b75b0254.png)
## Backend

A route was added to take in a package and constraint, and then redirect to the highest version that fits the constraint. Doing this work on the backend has several advantages: 
1. It is lazy. This lookup is only done when the link is clicked and taken to this route. 
2. It is easier. Code for parsing and comparing constraints already [exists](https://github.com/elm-lang/elm-package/blob/master/src/Elm/Package/Constraint.hs) 
3. It is faster. There is no need to fetch, parse, and figure what version to redirect to in elm when the backend already has all the information needed.  
