### PR TITLE
Make copying username/package easier

### DIFF
--- a/src/frontend/Component/Header.elm
+++ b/src/frontend/Component/Header.elm
@@ -68,7 +68,7 @@ center color kids =
 headerLinks model =
   h1 [ class "header" ] <|
     a [href "/", style ["text-decoration" => "none"]] [logo]
-    :: unrollRoute model.route
+    :: [ span [ style ["padding-left" => "20px", "margin-left" => "-20px"]] (unrollRoute model.route) ]
 
 
 -- helpers


### PR DESCRIPTION
This might be a solution for #27

### Before
![ezgif com-4120f46f18](https://cloud.githubusercontent.com/assets/3983879/20540925/5a554940-b0fb-11e6-8d1f-ccc64f0047fa.gif)
Margin from the logo is not allowing to copy the `user/package` part easily.

This is how I feel every time.

![](https://media.giphy.com/media/ToEPIf9eDupWg/giphy.gif)

### After
The fix is very simple with minimal changes.

![ezgif com-c5e470f8c3](https://cloud.githubusercontent.com/assets/3983879/20540922/5472811e-b0fb-11e6-8123-e33bbb3c26cd.gif)

