### PR TITLE
More polite language in design guidelines.

### DIFF
--- a/src/frontend/Page/Help/DesignGuidelines.elm
+++ b/src/frontend/Page/Help/DesignGuidelines.elm
@@ -195,9 +195,9 @@ Experienced users can go see if they like them and define them if they really wa
 That way the API can be nice and human readable *and* encourage its users to write code
 that is nice and human readable.
 
-Okay, but let's say you just don't care about recommendations and you have a great
+Finally, let's say you don't care about these recommendations and you have a great
 infix operator. Add them in a separate module. When someone sees an infix operator
 they are unfamiliar with, they can scan the imports for a `Whatever.Infix` module
-and limit the scope of their annoying search for your dumb operator.
+and limit the scope of their search for your operator.
 
 """


### PR DESCRIPTION
Original language sounded like it was calling the user and their decisions 'dumb', which is not helpful, especially when there are some legitimate uses for infix operators - for example, [parser libraries](https://github.com/elm-tools/parser) are typically made much more readable, not less, by appropriate use of operators, and similarly libraries that need operators with the same semantics as normal arithmetic (but can't just use `+` because there is mechanism for doing that in Elm).