### PR TITLE
Fix image scaling in docs

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -142,6 +142,10 @@ pre {
   margin-bottom: 0.5px
 }
 
+.markdown-block img {
+  max-width: 100%;
+}
+
 .docs-block {
   border-top: 1px solid #eeeeee;
   margin-top: 1em;


### PR DESCRIPTION
Prevents images in module-level doc comments from overflowing their container. 

Replaces https://github.com/elm/package.elm-lang.org/pull/242 (the classes referenced in this pr no longer seem to exist).

Fixes https://github.com/elm/package.elm-lang.org/issues/238

<details>
<summary>Before
</summary>

<img width="1034" alt="screen shot 2018-10-08 at 5 53 47 pm" src="https://user-images.githubusercontent.com/8811312/46641018-17998b80-cb24-11e8-8030-64a19c1b5d89.png">

</details>

<details>
<summary>After
</summary>

<img width="1041" alt="screen shot 2018-10-08 at 5 53 40 pm" src="https://user-images.githubusercontent.com/8811312/46641021-1bc5a900-cb24-11e8-98a4-0858278c1a40.png">

</details>

(Alternatively, it might be nice to allow `img` tags in the markdown. Suggesting this change as least invasive.)