### PR TITLE
Add elm version to docs sidebar

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -218,6 +218,11 @@ pre {
   padding-bottom: 10px;
 }
 
+.pkg-nav-version {
+  font-size: 0.8em;
+  font-weight: bold;
+}
+
 
 
 /* CATALOG */


### PR DESCRIPTION
When fetching elm packages, also gets the elm.json package info.
This is used to show the elm version in the docs sidebar so there is no confusion when getting to package links through google.
I added the package info to the model but I could just scale back to the elm version if it is too much.

 ![image](https://user-images.githubusercontent.com/25238976/47195877-9d7dc800-d3a9-11e8-992f-85229f4e5c2e.png)

#255 (-:
