### PR TITLE
Links to operator code blocks

### DIFF
--- a/src/frontend/Page/Docs/Block.elm
+++ b/src/frontend/Page/Docs/Block.elm
@@ -96,10 +96,13 @@ indentFour =
 viewBinop : Info -> Docs.Binop -> Html msg
 viewBinop info { name, comment, tipe } =
   let
+    nameInParens =
+      "(" ++ name ++ ")"
+
     nameHtml =
-      toBoldLink info ("(" ++ name ++ ")")
+      toBoldLink info nameInParens
   in
-  viewCodeBlock name comment <|
+  viewCodeBlock nameInParens comment <|
     case toLines info Other tipe of
       One _ line ->
         [ nameHtml :: space :: colon :: space :: line ]


### PR DESCRIPTION
The id of the code block will match the link's hash. Therefore the browser will jump to the correct section for direct links.

Solves #286