### PR TITLE
Add install instruction to package sidebar

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -218,7 +218,23 @@ pre {
   padding-bottom: 10px;
 }
 
+.pkg-nav-install {
+  display: block;
+  font-size: .875em;
+  border-radius: 2px;
+  overflow: scroll;
+  white-space: nowrap;
+  margin-top: 1rem;
+}
 
+.pkg-nav-install span {
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -khtml-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
 
 /* CATALOG */
 

--- a/src/frontend/Page/Docs.elm
+++ b/src/frontend/Page/Docs.elm
@@ -401,6 +401,8 @@ viewSidebar model =
     [ lazy4 viewReadmeLink model.author model.project model.version model.focus
     , br [] []
     , lazy4 viewBrowseSourceLink model.author model.project model.version model.latest
+    , h2 [] [ text "Install" ]
+    , lazy2 viewInstallInstruction model.author model.project
     , h2 [] [ text "Module Docs" ]
     , input
         [ placeholder "Search"
@@ -535,6 +537,17 @@ viewBrowseSourceLinkHelp author project version =
   in
   a [ class "pkg-nav-module", href url ] [ text "Browse Source" ]
 
+
+
+-- VIEW INSTALL INSTRUCTION
+
+
+viewInstallInstruction : String -> String -> Html msg
+viewInstallInstruction author project =
+  code [ class "pkg-nav-install" ]
+    [ span [] [ text "> "]
+    , text ("elm install " ++ author ++ "/" ++ project)
+    ]
 
 
 -- VIEW "MODULE" LINK


### PR DESCRIPTION
## What
Copiable command line instruction that will install the package you're looking at.

## Behaviour
* Triple click or drag to select text.
* Doesn't select `>` symbol.

## Notes
* Tripple click always selects extra new line due to setting css `overflow`, not sure if or how this should be solved.
* Could be made more interactive by actually copying on click.

## Preview
<img width="1141" alt="screenshot 2019-01-04 at 17 55 54" src="https://user-images.githubusercontent.com/18724157/50700421-d04f6800-104a-11e9-9c8f-6608fd788f31.png">

## Fixes
#27 