### PR TITLE
Fixed a bug in arguments to sed in get-fonts.sh

### DIFF
--- a/get-fonts.sh
+++ b/get-fonts.sh
@@ -24,7 +24,7 @@ function download {
 		fi
 	done
 
-	sed -i "" "s!https.*/\([a-zA-Z0-9_-]*\.woff2\)!/$DIR/\1!g" $CSS
+	sed -i "s!https.*/\([a-zA-Z0-9_-]*\.woff2\)!/$DIR/\1!g" $CSS
 	gzip -9 $CSS
 }
 


### PR DESCRIPTION
I tried running `get-fonts.sh` and found that there was a small bug in the `sed` command that sets the relative path to the font files. There's an extra empty string argument.

Here's what happens when you run what is currently committed on Linux:

![get-fonts-error](https://user-images.githubusercontent.com/6189390/76154240-a35b7280-609e-11ea-84c1-4516d04fe068.png)

This commit removed the extra empty string argument and fixes that error.