### PR TITLE
Prevent search boxes from auto-correcting

### DIFF
--- a/src/frontend/Page/Docs.elm
+++ b/src/frontend/Page/Docs.elm
@@ -484,6 +484,9 @@ viewSidebar model =
         [ placeholder "Search"
         , value model.query
         , onInput QueryChanged
+        , spellcheck False
+        , attribute "autocapitalize" "off"
+        , attribute "autocorrect" "off"
         ]
         []
     , viewSidebarModules model

--- a/src/frontend/Page/Search.elm
+++ b/src/frontend/Page/Search.elm
@@ -9,7 +9,7 @@ module Page.Search exposing
 
 import Elm.Version as V
 import Html exposing (..)
-import Html.Attributes exposing (autofocus, class, href, placeholder, style, value)
+import Html.Attributes exposing (autofocus, class, href, placeholder, style, value, spellcheck, attribute)
 import Html.Events exposing (..)
 import Html.Lazy exposing (..)
 import Html.Keyed as Keyed
@@ -117,6 +117,9 @@ viewSearch query entries =
         , value query
         , onInput QueryChanged
         , autofocus True
+        , spellcheck False
+        , attribute "autocapitalize" "off"
+        , attribute "autocorrect" "off"
         ]
         []
     , case entries of


### PR DESCRIPTION
I often find that my browser's auto-correction is unhelpful when searching the package list and package docs. On macOS/Safari at least, I'll start typing and find the package I'm looking for, but trying to click the package causes the auto-correction to occur, changing my search term.

![2020-06-16 15 34 06](https://user-images.githubusercontent.com/510520/84788460-0e460f00-afe7-11ea-8b56-ce4fde3d7ae5.gif)

This pull request prevents the browser from doing any correction, including a couple of Safari-specific attributes.

It's particularly noticeable on the package search page (because the browser not understanding Github usernames), so the changes to `Page.Search` might be more valuable than the changes made to `Page.Docs`.