### PR TITLE
Add links to type aliases

### DIFF
--- a/src/frontend/Page/Docs/Block.elm
+++ b/src/frontend/Page/Docs/Block.elm
@@ -185,11 +185,19 @@ type alias TypeNameDict =
 makeInfo : String -> String -> Maybe V.Version -> String -> List Docs.Module -> Info
 makeInfo author project version moduleName docsList =
   let
-    addUnion home union docs =
-      Dict.insert (home ++ "." ++ union.name) (home, union.name) docs
+    addType home typeName docs =
+      Dict.insert (home ++ "." ++ typeName) ( home, typeName ) docs
 
     addModule docs dict =
-      List.foldl (addUnion docs.name) dict docs.unions
+      let
+        types : List String
+        types =
+          List.concat
+            [ List.map .name docs.unions
+            , List.map .name docs.aliases
+            ]
+      in
+      List.foldl (addType docs.name) dict types
   in
     Info author project version moduleName <|
       List.foldl addModule Dict.empty docsList


### PR DESCRIPTION
Hi :wave: 

This adds links to type aliases.

## Background

I noticed a while back that some types get links (in the type of a function for instance), while some of them don't. I wondered why, and it looks it's as simple as custom types get links, while type aliases don't.

You can see an example here: https://package.elm-lang.org/packages/mdgriffith/elm-ui/latest/Element
`Element` is a type alias, and it doesn't show up as a link in the signature of `none` below it.

## Additional information

If/when this gets merged, I'll make a similar PR to dmy.elm.fr and to `elm-doc-preview` so that they can also benefit from the change.

I could not test this change out as I didn't know how to get the server running. I did test it however with `elm-doc-preview` ([see my fork and branch here](https://github.com/jfmengels/elm-doc-preview/tree/add-links-to-type-aliases)).

I can't think of any drawbacks to include these links, but if you do see any, please let me know!